### PR TITLE
cannot get the right character position of UILabel in TruncateTail mode

### DIFF
--- a/Example/AttributedStringDemo/ASDViewController.m
+++ b/Example/AttributedStringDemo/ASDViewController.m
@@ -128,6 +128,7 @@
         NSUInteger pos = [self.footerLabel characterIndexAtPoint:tapPoint];
         if (pos != NSNotFound)
         {
+            NSLog(@"POS: %zi", pos);
             NSURL* urlTapped = [self.footerLabel.attributedText URLAtIndex:pos effectiveRange:NULL];
             if (urlTapped) [[UIApplication sharedApplication] openURL:urlTapped];
         }

--- a/Example/AttributedStringDemo/ASDViewController.xib
+++ b/Example/AttributedStringDemo/ASDViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6254" systemVersion="14C109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="7706" systemVersion="14F27" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6247"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ASDAppDelegate"/>
@@ -42,15 +42,14 @@
                             <outlet property="delegate" destination="h5X-C2-Udq" id="GLF-WG-iXX"/>
                         </connections>
                     </searchBar>
-                    <label opaque="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="320" translatesAutoresizingMaskIntoConstraints="NO" id="y66-pk-8fX">
+                    <label opaque="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="center" lineBreakMode="headTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="320" translatesAutoresizingMaskIntoConstraints="NO" id="y66-pk-8fX">
                         <rect key="frame" x="0.0" y="528" width="320" height="40"/>
                         <color key="backgroundColor" red="0.87740945820000005" green="0.94723397490000005" blue="0.99971258640000005" alpha="1" colorSpace="calibratedRGB"/>
                         <gestureRecognizers/>
                         <constraints>
                             <constraint firstAttribute="height" constant="40" id="J6u-KC-hvr"/>
                         </constraints>
-                        <string key="text">Read more
-on my wiki on GitHub !</string>
+                        <string key="text">Read more on my wiki on GitHub ! This is a automatic word wrap uilabel using truncate-like mode. Supports for TruncateTail, TruncateHead and TruncateMiddle.</string>
                         <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="14"/>
                         <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                         <nil key="highlightedColor"/>

--- a/Source/UILabel+OHAdditions.m
+++ b/Source/UILabel+OHAdditions.m
@@ -23,6 +23,7 @@
  ******************************************************************************/
 
 #import "UILabel+OHAdditions.h"
+#import "NSMutableAttributedString+OHAdditions.h"
 
 @implementation UILabel (OHAdditions)
 
@@ -35,10 +36,24 @@
     return textContainer;
 }
 
+- (NSTextStorage*)currentTextStorage
+{
+    NSAttributedString* attributedText = self.attributedText;
+    if (
+        self.lineBreakMode == NSLineBreakByTruncatingTail
+        || self.lineBreakMode == NSLineBreakByTruncatingMiddle
+        || self.lineBreakMode == NSLineBreakByTruncatingHead) {
+        NSMutableAttributedString* temp = [attributedText mutableCopy];
+        [temp setLineBreakMode:NSLineBreakByWordWrapping];
+        attributedText = temp;
+    }
+    return [[NSTextStorage alloc] initWithAttributedString:attributedText];
+}
+
 - (NSUInteger)characterIndexAtPoint:(CGPoint)point
 {
     NSTextContainer* textContainer = self.currentTextContainer;
-    NSTextStorage *textStorage = [[NSTextStorage alloc] initWithAttributedString:self.attributedText];
+    NSTextStorage *textStorage = self.currentTextStorage;
 
     NSLayoutManager *layoutManager = [NSLayoutManager new];
     [textStorage addLayoutManager:layoutManager];


### PR DESCRIPTION
Hi, thanks for your great work.

I found the layoutManager will not auto-wrap attributedString when lineBreakMode is TruncateTail. So we must reset the lineBreakMode of attributedString. 

fix: @selector(characterIndexAtPoint:) return the right index of UILabel in Truncate\* mode when auto-wrap.

I hope you would accept it. 
